### PR TITLE
Default to current window in jump_to_item

### DIFF
--- a/lua/trouble/util.lua
+++ b/lua/trouble/util.lua
@@ -15,7 +15,7 @@ function M.jump_to_item(win, precmd, item)
   else
     vim.cmd("buffer " .. item.bufnr)
   end
-  vim.api.nvim_win_set_cursor(win, { item.start.line + 1, item.start.character })
+  vim.api.nvim_win_set_cursor(win or 0, { item.start.line + 1, item.start.character })
 end
 
 function M.fix_mode(opts)


### PR DESCRIPTION
This PR fixes an error where sometimes, jump_to_item would crash in case the window-id was nil for some reason.
By just defaulting to 0 in that case, we can avoid that error trivially.
This error occurred when auto_jump was used.
The fix does not introduce any other breaking changes or behavior changes.

https://github.com/folke/trouble.nvim/pull/175#issue-1208024881